### PR TITLE
Adding a minimal inference example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Unlimiformer is a method for augmenting pretrained encoder-decoder models with a
 Unlimiformer can be used to improve performance of an already-trained model. However, for best results, the model should be trained with Unlimiformer. 
 
 ## Getting Started
-Paste these files from ```src``` into your source code folder.
+Paste the files from ```src``` into your source code folder.
 
-You'll need to set values for the Unlimiformer-specific arguments outlined in ```usage.py```-- you can add these arguments wherever you usually process hyperparameters. 
+You'll need to set values for the Unlimiformer-specific arguments outlined in ```usage.py```-- you can add these arguments wherever you usually process hyperparameters. To use the model, you must set ```test_unlimiformer=True```. For datastore usage, the model must be in evaluation model (e.g. call ```model.eval()``` before inference). 
 
-To use the model, you must set ```test_unlimiformer=True```.
+```inference-example.py``` outlines a minimal example for running a sequence through an Unlimiformer model, using the default arguments. 
 
 ```run.py``` is an example of a full training setup that integrates Unlimiformer, adopted from [SLED](https://github.com/Mivg/SLED) -- this is likely more complex than you will need. 
 

--- a/src/inference-example.py
+++ b/src/inference-example.py
@@ -1,0 +1,45 @@
+from unlimiformer import Unlimiformer
+from random_training_unlimiformer import RandomTrainingUnlimiformer
+from usage import UnlimiformerArguments, training_addin
+
+from transformers import BartForConditionalGeneration, AutoTokenizer
+from datasets import load_dataset
+
+# example using booksum
+modelname = "abertsch/unlimiformer-bart-booksum-alternating"
+dataset = load_dataset("abertsch/booksum-fullbooks", "validation")
+
+tokenizer = AutoTokenizer.from_pretrained("facebook/bart-base")
+model = BartForConditionalGeneration.from_pretrained(modelname)
+
+example_input = dataset['train'][0]['book']
+
+example = tokenizer(example_input, truncation=False, return_tensors="pt")
+truncated_example = tokenizer(example_input, truncation=True, max_length=1024, return_tensors="pt")
+
+print(f"INPUT LENGTH (tokens): {example['input_ids'].shape[-1]}")
+
+
+defaults = UnlimiformerArguments()
+unlimiformer_kwargs = {
+            'layer_begin': defaults.layer_begin, 
+            'layer_end': defaults.layer_end,
+            'unlimiformer_head_num': defaults.unlimiformer_head_num, 
+            'exclude_attention': defaults.unlimiformer_exclude, 
+            'chunk_overlap': defaults.unlimiformer_chunk_overlap,
+            'model_encoder_max_len': defaults.unlimiformer_chunk_size,
+            'verbose': defaults.unlimiformer_verbose, 'tokenizer': tokenizer,
+            'unlimiformer_training': defaults.unlimiformer_training,
+            'use_datastore': defaults.use_datastore,
+            'flat_index': defaults.flat_index,
+            'test_datastore': defaults.test_datastore,
+            'reconstruct_embeddings': defaults.reconstruct_embeddings,
+            'gpu_datastore': defaults.gpu_datastore,
+            'gpu_index': defaults.gpu_index
+}
+#print(model.generate(**truncated_example, max_length=1024))
+truncated_out = tokenizer.batch_decode(model.generate(**truncated_example, max_length=1024))
+model = Unlimiformer.convert_model(model, **unlimiformer_kwargs)
+
+unlimiformer_out = tokenizer.decode(model.generate(**example, max_length=1024))
+

--- a/src/usage.py
+++ b/src/usage.py
@@ -11,7 +11,7 @@ class UnlimiformerArguments:
     Arguments pertaining to what data we are going to input our model for training and eval.
     """
     test_unlimiformer: Optional[bool] = field(
-        default=False,
+        default=True,
         metadata={
             "help": "whether to use KNN."
         },


### PR DESCRIPTION
Addressing #5 and some other comments:

```inference-example.py``` is a minimal example for running inference with Unlimiformer. The default model in this example is our GovReport Unlimiformer model, but this can be swapped out for any other pretrained encoder-decoder (e.g. BART, PRIMERA) by simply changing the ```modelname``` and tokenizer used. 